### PR TITLE
Fix HUD layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@
 
 # debug information files
 *.dwo
+
+# Local macOS metadata
+.DS_Store
+
+# CMake build directories
+/build/
+/build-*/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,34 @@
 # Witch-Potion-Hunt
 
-This is where we work on the game Witch Potion Hunt.
+Witch Potion Hunt is a small 2D action-platformer built with C++ and SFML. You play as a witch, collect coins, fight enemies with spells, unlock movement abilities, and enter the portal to advance through the game.
+
+## Gameplay Overview
+
+- There are 3 levels.
+- Each level contains 4 coins to collect.
+- The portal opens only after all 4 coins are collected.
+- Enemies damage your HP on contact or by shooting projectiles.
+- Spells consume mana, and mana restores over time.
+- Level 2 unlocks double jump.
+- Level 3 unlocks climbing on green vines.
+
+## Controls
+
+- Move: `A` / `D` or `Left` / `Right`
+- Jump: `Space`, `W`, or `Up`
+- Climb: `W` / `S` or `Up` / `Down` while touching a green climb wall
+- Select spells: `1`, `2`, `3`
+- Cast spell: `Left Click`
+- Restart after win or loss: `R` or `Enter`
+- Leave settings / confirm some overlays: `Enter` or `Escape`
+
+## Tech Notes
+
+- The project uses CMake and automatically downloads SFML `3.0.2` during configuration.
+- The game uses generated audio, so no external sound asset pack is required.
+- The codebase targets C++17.
 
 ## Build And Run
-
-This project uses CMake and downloads SFML 3 automatically during configuration, so you do not need to install SFML manually.
 
 ### Clone
 
@@ -46,6 +70,8 @@ Configure the project:
 ```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 ```
+
+The first configure can take a little longer because CMake downloads SFML and builds its dependencies.
 
 ### Build
 

--- a/main.cpp
+++ b/main.cpp
@@ -200,6 +200,14 @@ sf::Vector2f GetEventWorldPosition(const sf::RenderWindow& window, sf::Vector2i 
         };
     }
 
+    sf::Vector2f GetLeftHudPanelPosition(float topY)
+    {
+        return {
+            18.0f,
+            topY
+        };
+    }
+
     float GetVectorLength(sf::Vector2f vector)
     {
         return std::sqrt(vector.x * vector.x + vector.y * vector.y);
@@ -1301,7 +1309,7 @@ sf::Vector2f GetEventWorldPosition(const sf::RenderWindow& window, sf::Vector2i 
     void drawHUDfairy(sf::RenderWindow& window, std::size_t levelindex, bool portalready, float elapsedSeconds)
     {
         const sf::Vector2f panelSize(430.0f, 132.0f);
-        const sf::Vector2f panelPosition = GetRightHudPanelPosition(window, panelSize, 228.0f);
+        const sf::Vector2f panelPosition = GetRightHudPanelPosition(window, panelSize, 124.0f);
         sf::RectangleShape panel(panelSize);
         panel.setPosition(panelPosition);
         panel.setFillColor(sf::Color(27, 23, 40, 205));
@@ -1413,7 +1421,7 @@ sf::Vector2f GetEventWorldPosition(const sf::RenderWindow& window, sf::Vector2i 
         std::size_t levelindex, bool portalready, float elapsedSeconds)
     {
         const sf::Vector2f panelSize(430.0f, 198.0f);
-        const sf::Vector2f panelPosition = GetRightHudPanelPosition(window, panelSize, 16.0f);
+        const sf::Vector2f panelPosition = GetLeftHudPanelPosition(16.0f);
         const auto panelOffset = [&](float x, float y)
         {
             return panelPosition + sf::Vector2f(x, y);

--- a/rendering.hpp
+++ b/rendering.hpp
@@ -952,15 +952,20 @@ inline void drawHudAbilityBadge(sf::RenderWindow& window,
 
 inline void drawCoinsHud(sf::RenderWindow& window, const Level& level)
 {
-    sf::RectangleShape panel({ 338.0f, 92.0f });
-    panel.setPosition({ 924.0f, 16.0f });
+    const sf::Vector2f panelSize(338.0f, 92.0f);
+    const sf::Vector2f panelPosition(
+        static_cast<float>(window.getSize().x) - panelSize.x - 18.0f,
+        16.0f);
+
+    sf::RectangleShape panel(panelSize);
+    panel.setPosition(panelPosition);
     panel.setFillColor(sf::Color(24, 22, 34, 220));
     panel.setOutlineThickness(2.0f);
     panel.setOutlineColor(sf::Color(142, 113, 198, 150));
     window.draw(panel);
 
-    drawPixelRect(window, { 926.0f, 18.0f }, { 334.0f, 5.0f }, sf::Color(255, 255, 255, 28));
-    drawBlockLabel(window, "COINS TO COLLECT", { 940.0f, 29.0f }, 2.0f, 2.0f, sf::Color(241, 231, 189));
+    drawPixelRect(window, panelPosition + sf::Vector2f(2.0f, 2.0f), { 334.0f, 5.0f }, sf::Color(255, 255, 255, 28));
+    drawBlockLabel(window, "COINS TO COLLECT", panelPosition + sf::Vector2f(16.0f, 13.0f), 2.0f, 2.0f, sf::Color(241, 231, 189));
 
     const int collectedCount = static_cast<int>(std::count_if(level.ingredients.begin(),
         level.ingredients.end(),
@@ -972,13 +977,13 @@ inline void drawCoinsHud(sf::RenderWindow& window, const Level& level)
     for (std::size_t i = 0; i < level.ingredients.size(); ++i)
     {
         drawHudIngredientToken(window,
-            { 954.0f + static_cast<float>(i) * 34.0f, 70.0f },
+            panelPosition + sf::Vector2f(30.0f + static_cast<float>(i) * 34.0f, 54.0f),
             static_cast<int>(i) < collectedCount,
             i);
     }
 
     const std::string progress = std::to_string(collectedCount) + "/" + std::to_string(level.ingredients.size());
-    drawBlockLabel(window, progress, { 1104.0f, 61.0f }, 2.0f, 2.0f, sf::Color(235, 232, 255));
+    drawBlockLabel(window, progress, panelPosition + sf::Vector2f(180.0f, 45.0f), 2.0f, 2.0f, sf::Color(235, 232, 255));
 }
 
 inline void drawConfetti(sf::RenderWindow& window, float elapsedSeconds)


### PR DESCRIPTION
@IManess2024 FYI

Both HUD groups were using right-side anchoring, so the player HUD moved to the top right.

I fixed it. Feel free to merge it after you have checked it.